### PR TITLE
chore: update `./scripts/test-manual-e2e.sh`

### DIFF
--- a/scripts/test-manual-e2e.sh
+++ b/scripts/test-manual-e2e.sh
@@ -58,11 +58,14 @@ info ""
 read -n 1
 adb shell am start -n com.facebook.react.uiapp/.RNTesterActivity
 
+success "Installing CocoaPods dependencies"
+rm -rf RNTester/Pods
+(cd RNTester && pod install)
+
 info "Press any key to open the workspace in Xcode, then build and test manually."
 info ""
 read -n 1
-success "Installing CocoaPods dependencies"
-rm -rf RNTester/Pods && cd RNTester && pod install
+
 open "RNTester/RNTesterPods.xcworkspace"
 
 info "When done testing RNTester app on iOS and Android press any key to continue."
@@ -113,7 +116,7 @@ info ""
 info "Press any key to open the project in Xcode"
 info ""
 read -n 1
-open "/tmp/${project_name}/ios/${project_name}.xcodeproj"
+open "/tmp/${project_name}/ios/${project_name}.xcworkspace"
 
 cd "$repo_root"
 


### PR DESCRIPTION
Recent changes broke the script - wrong path to open `RNTesterPods.xcworkspace` and wrong `RNTesterProject.xcodeproj`. This PR is a simple and short fix to make it run.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[CATEGORY] [TYPE] - Message

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
